### PR TITLE
WIP server middleware implementation

### DIFF
--- a/src/server/charge.ts
+++ b/src/server/charge.ts
@@ -1,0 +1,8 @@
+import { BigNumber } from "bignumber.js";
+import { Charge } from "./types.js";
+import { PayMcpConfig } from "./types.js";
+import { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+
+export function getCharge(msg: JSONRPCMessage, price: PayMcpConfig["price"]): Charge | undefined {
+  return undefined;
+}

--- a/src/server/context.test.ts
+++ b/src/server/context.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { withContext, getContext } from './context.js';
+import { PayMcpContext } from './types.js';
+import { BigNumber } from 'bignumber.js';
+
+describe('AsyncLocalStorage Context', () => {
+  it('should make config available within the context', () => {
+    const testContext: Required<PayMcpContext> = {
+      logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+    };
+
+    withContext(testContext, () => {
+      const context = getContext();
+      expect(context).toBe(testContext);
+    });
+  });
+
+  it('should make config available in event callbacks', () => {
+    return new Promise<void>((resolve) => {
+      const testContext: Required<PayMcpContext> = {
+        logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+      };
+
+      withContext(testContext, () => {
+        // Simulate setting up an event listener (like res.on('finish'))
+        const eventEmitter = new EventTarget();
+        
+        eventEmitter.addEventListener('test', () => {
+          // This callback should have access to the config
+          const context = getContext();
+          expect(context).toBe(testContext);
+          resolve();
+        });
+
+        // Trigger the event
+        eventEmitter.dispatchEvent(new Event('test'));
+      });
+    });
+  });
+}); 

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -1,0 +1,36 @@
+import { AsyncLocalStorage } from "async_hooks";
+import { PayMcpContext } from "./types.js";
+import { ConsoleLogger } from "../logger.js";
+
+// Create an AsyncLocalStorage instance to store config per request
+const contextStorage = new AsyncLocalStorage<Required<PayMcpContext>>();
+
+// Default test context for when we're in a test environment
+const defaultTestContext: Required<PayMcpContext> = {
+  logger: new ConsoleLogger(),
+};
+
+// Helper function to check if we're in a test environment
+function isTestEnvironment(): boolean {
+  return process.env.NODE_ENV === 'test' || 
+         process.env.VITEST === 'true' ||
+         typeof globalThis !== 'undefined' && 'vitest' in globalThis;
+}
+
+// Helper function to get the current request's config
+export function getContext(): Required<PayMcpContext> {
+  const config = contextStorage.getStore();
+  if (!config) {
+    // If we're in a test environment, return a default context instead of throwing
+    if (isTestEnvironment()) {
+      return defaultTestContext;
+    }
+    throw new Error('getContext() called outside of a paymcp request context');
+  }
+  return config;
+}
+
+// Helper function to run code within a config context
+export function withContext<T>(config: Required<PayMcpContext>, fn: () => T | Promise<T>): T | Promise<T> {
+  return contextStorage.run(config, fn);
+} 

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -1,0 +1,59 @@
+import { IncomingMessage } from "node:http";
+import getRawBody from "raw-body";
+import contentType from "content-type";
+import { JSONRPCMessage, JSONRPCMessageSchema } from "@modelcontextprotocol/sdk/types.js";
+import { ZodError } from "zod";
+import { getContext } from "./context";
+
+// Useful reference for dealing with low-level http requests:
+// https://github.com/modelcontextprotocol/typescript-sdk/blob/c6ac083b1b37b222b5bfba5563822daa5d03372e/src/server/streamableHttp.ts#L375
+
+// Using the same value as MCP SDK
+const MAXIMUM_MESSAGE_SIZE = "4mb";
+
+export async function parseMcpMessages(req: IncomingMessage, parsedBody?: unknown): Promise<JSONRPCMessage[]> {
+  const context = getContext();
+  parsedBody = parsedBody ?? await parseBody(req);
+
+  let messages: JSONRPCMessage[];
+
+  try {
+    // handle batch and single messages
+    if (Array.isArray(parsedBody)) {
+      messages = parsedBody.map(msg => JSONRPCMessageSchema.parse(msg));
+    } else {
+      messages = [JSONRPCMessageSchema.parse(parsedBody)];
+    }
+  } catch (error) {
+    // If Zod validation fails, log the error and return empty array
+    if (error instanceof ZodError) {
+      context.logger.warn(`Invalid JSON-RPC message format: ${error.message}`);
+    } else {
+      context.logger.error(`Unexpected error parsing JSON-RPC messages: ${error}`);
+    }
+    return [];
+  }
+
+  return messages;
+}
+
+export async function parseBody(req: IncomingMessage): Promise<unknown> {
+  try {
+    const ct = req.headers["content-type"];
+
+    let encoding = "utf-8";
+    if (ct) {
+      const parsedCt = contentType.parse(ct);
+      encoding = parsedCt.parameters.charset ?? "utf-8";
+    }
+  
+    const body = await getRawBody(req, {
+      limit: MAXIMUM_MESSAGE_SIZE,
+      encoding,
+    });
+    return JSON.parse(body.toString());
+  } catch (error) {
+    console.error(error);
+    return undefined;
+  }
+}

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { paymcp } from './index.js';
+import httpMocks from 'node-mocks-http';
+import { mockAuthorizationServer, mockResourceServer } from '../testHelpers.js';
+import fetchMock from 'fetch-mock';
+import { ConsoleLogger, LogLevel } from '../logger.js';
+import { OAuthResourceClient } from '../oAuthResource.js';
+import { BigNumber } from 'bignumber.js';
+import { EventEmitter } from 'events';
+
+describe('paymcp', () => {
+  let consoleSpy: {
+    debug: ReturnType<typeof vi.spyOn>;
+  };
+
+  beforeEach(() => {
+    consoleSpy = {
+      debug: vi.spyOn(console, 'debug').mockImplementation(() => {})
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should run code at request start and finish', async () => {
+    const { req, res } = httpMocks.createMocks(
+      {
+        method: 'POST',
+        path: '/mcp/message',
+        body: {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call:testTool',
+          params: { name: 'test' }
+        }
+      },
+      { eventEmitter: EventEmitter }
+    );
+
+    const middleware = paymcp({
+      price: new BigNumber(0.01),
+      destination: 'test-destination',
+      logger: new ConsoleLogger({level: LogLevel.DEBUG})
+    });
+
+    // Create a mock next function that we can track
+    const next = vi.fn();
+
+    // Call the middleware
+    middleware(req as any, res, next);
+
+    // 1. Assert we logged the start line immediately
+    expect(consoleSpy.debug).toHaveBeenCalledWith('[paymcp] Request started - POST /mcp/message');
+    expect(next).toHaveBeenCalled();
+
+    // 2. Assert the finish line has NOT been called yet (response hasn't finished)
+    expect(consoleSpy.debug).toHaveBeenCalledTimes(1);
+
+    // 3. Simulate the response finishing by calling end() which triggers the 'finish' event
+    res.end();
+
+    // 4. Now assert we logged the finish line when the response was finished
+    expect(consoleSpy.debug).toHaveBeenCalledWith('[paymcp] Request finished - POST /mcp/message');
+
+    // Verify the order and count of calls
+    expect(consoleSpy.debug).toHaveBeenCalledTimes(2);
+    const calls = consoleSpy.debug.mock.calls;
+    expect(calls[0][0]).toBe('[paymcp] Request started - POST /mcp/message');
+    expect(calls[1][0]).toBe('[paymcp] Request finished - POST /mcp/message');
+  });
+
+  it('should call token introspection when MCP tool call request comes in with Authorization header', async () => {
+    // Create a mock OAuthResourceClient
+    const mockOAuthClient = {
+      introspectToken: vi.fn().mockResolvedValue({
+        active: true,
+        sub: 'test-user',
+        scope: 'tools:read',
+        aud: 'https://example.com'
+      })
+    } as unknown as OAuthResourceClient;
+
+    const { req, res } = httpMocks.createMocks(
+      {
+        method: 'POST',
+        path: '/mcp/message',
+        headers: {
+          authorization: 'Bearer test-access-token'
+        },
+        body: {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call:testTool',
+          params: { name: 'test' }
+        }
+      }
+    );
+
+    const middleware = paymcp({
+      price: new BigNumber(0.01),
+      destination: 'test-destination',
+      oAuthResourceClient: mockOAuthClient
+    });
+    const next = vi.fn();
+    middleware(req as any, res as any, next);
+
+    expect(mockOAuthClient.introspectToken).toHaveBeenCalledWith(
+      'https://auth.paymcp.com',
+      'test-access-token',
+      undefined
+    );
+    expect(mockOAuthClient.introspectToken).toHaveBeenCalledTimes(1);
+  });
+
+});

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,0 +1,60 @@
+import { ConsoleLogger } from "../logger.js";
+import { OAuthResourceClient } from "../oAuthResource.js";
+import { SqliteOAuthDb } from "../oAuthDb.js";
+import { PayMcpConfig } from "./types.js";
+import { getMcpOperations } from "./mcpOperation.js";
+import { getCharge } from "./charge.js";
+import { checkToken } from "./token.js";
+import { sendOAuthChallenge } from "./oAuthChallenge.js";
+import { setUser } from "./user.js";
+import { getRefunds, processRefunds } from "./refund.js";
+import { parseMcpMessages } from "./http.js";
+import { Request, Response, NextFunction } from "express";
+import { withContext, getContext } from "./context.js";
+
+export const DEFAULT_CONFIG: Required<Omit<PayMcpConfig, 'price' | 'destination'>> = {
+  mountPath: '/',
+  currency: 'USDC' as const,
+  network: 'solana' as const,
+  server: 'https://auth.paymcp.com',
+  payeeName: null,
+  allowHttp: process.env.NODE_ENV === 'development',
+  refundErrors: true,
+  logger: new ConsoleLogger(),
+  oAuthResourceClient: new OAuthResourceClient({db: new SqliteOAuthDb()})
+};
+
+export function paymcp(args: PayMcpConfig): (req: Request, res: Response, next: NextFunction) => void {
+  const config = Object.freeze({ ...DEFAULT_CONFIG, ...args });
+
+  return async (req: Request, res: Response, next: NextFunction) => {
+    // Set the request-global context that can be used in handlers
+    return withContext({logger: config.logger}, async () => {
+      const context = getContext();
+      context.logger.debug(`Request started - ${req.method} ${req.path}`);
+
+      const messages = await parseMcpMessages(req, req.body);
+      const charges = messages.map(msg => getCharge(msg, config.price)).filter(c => c !== undefined);
+      // No charges mean no auth required
+      if (charges.length === 0) { next(); return; }
+
+      const tokenCheck = checkToken(req, charges, config);
+      if(!tokenCheck.passes) {
+        sendOAuthChallenge(res, tokenCheck);
+        return;
+      }
+      const user = setUser(req, tokenCheck.token);
+
+      // Listen for when the response is finished
+      res.on('finish', () => {
+        const refunds = getRefunds(res, config.refundErrors, charges);
+        processRefunds(user, refunds, config);
+        
+        context.logger.debug(`Request finished - ${req.method} ${req.path}`);
+      });
+      
+      // Call next() to continue to the next middleware
+      next();
+    });
+  };
+}

--- a/src/server/mcpOperation.test.ts
+++ b/src/server/mcpOperation.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { getMcpOperations } from './mcpOperation.js';
+import { JSONRPCRequest } from "@modelcontextprotocol/sdk/types.js";
+import { Readable } from 'stream';
+import { IncomingMessage } from 'http';
+
+function toolBody({toolName = 'testTool', args = {paramOne: 'test'}}: {
+  toolName?: string,
+  args?: any
+}){
+  return {
+    jsonrpc: "2.0" as const,
+    method: "tools/call",
+    params: {
+      name: toolName,
+      arguments: args,
+    },
+    id: "call-1",
+  };
+}
+
+function createIncomingMessage(bodyObj: any, method = 'POST', headers = {'content-type': 'application/json'}) {
+  const bodyString = JSON.stringify(bodyObj);
+  const stream = new Readable({
+    read() {
+      this.push(bodyString);
+      this.push(null);
+    }
+  }) as IncomingMessage;
+  stream.method = method;
+  stream.headers = headers;
+  return stream;
+}
+
+describe('getMcpOperations', () => {
+  it('should extract a tool operation', async () => {
+    const req = createIncomingMessage(toolBody({toolName: 'testTool'}));
+    const ops = await getMcpOperations(req);
+    expect(ops).toEqual(['tools/call:testTool']);
+  });
+
+  it('should return an empty array for a post with a non-MCP body', async () => {
+    const req = createIncomingMessage({ not: 'a-mcp-message' });
+    const ops = await getMcpOperations(req);
+    expect(ops).toEqual([]);
+  });
+
+  it('should return an empty array for GET requests', async () => { 
+    const req = createIncomingMessage({}, 'GET');
+    const ops = await getMcpOperations(req);
+    expect(ops).toEqual([]);
+  });
+
+  it('should return multiple operations for a request with multiple MCP tool messages', async () => {
+    const req = createIncomingMessage([
+      toolBody({toolName: 'testTool'}),
+      toolBody({toolName: 'testTool2'})
+    ]);
+    const ops = await getMcpOperations(req);
+    expect(ops).toEqual(['tools/call:testTool', 'tools/call:testTool2']);
+  });
+});

--- a/src/server/mcpOperation.ts
+++ b/src/server/mcpOperation.ts
@@ -1,0 +1,40 @@
+import { IncomingMessage } from "node:http";
+import { McpOperation } from "./types.js";
+import { parseMcpMessages } from "./http.js";
+import { JSONRPCMessage, JSONRPCRequest, isJSONRPCRequest } from "@modelcontextprotocol/sdk/types.js";
+
+export async function getMcpOperations(req: IncomingMessage, parsedMcpMessages?: JSONRPCMessage[]): Promise<McpOperation[]> {
+  // Useful reference for dealing with low-level http requests:
+  // https://github.com/modelcontextprotocol/typescript-sdk/blob/c6ac083b1b37b222b5bfba5563822daa5d03372e/src/server/streamableHttp.ts#L375
+  if (!req.method) {
+    return [];
+  }
+  const isPost = req.method.toLowerCase() === 'post';
+  if (!isPost) {
+    return [];
+  }
+  parsedMcpMessages = parsedMcpMessages ?? await parseMcpMessages(req);
+  if (parsedMcpMessages.length === 0) {
+    return [];
+  }
+
+  const operations = parsedMcpMessages.map(msg => mcpOperation(msg));
+  return operations.filter(op => op !== null);
+}
+
+function mcpOperation(msg: JSONRPCMessage): McpOperation | null {
+  // Try to get the operation from the jsonRpc message
+  if(!isJSONRPCRequest(msg)) {
+    return null;
+  }
+  const mcpRequest = msg as JSONRPCRequest;
+  let op = mcpRequest.method;
+  const toolName = mcpRequest.params?.name;
+  if (toolName) {
+    op = `${op}:${toolName}`
+  }
+  if (!op) {
+    return null;
+  }
+  return op;
+}

--- a/src/server/oAuthChallenge.ts
+++ b/src/server/oAuthChallenge.ts
@@ -1,0 +1,5 @@
+import { Response } from "express";
+import { TokenCheck } from "./types";
+
+export function sendOAuthChallenge(res: Response, tokenCheck: TokenCheck): void {
+}

--- a/src/server/refund.test.ts
+++ b/src/server/refund.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { paymcp } from './index.js';
+import httpMocks from 'node-mocks-http';
+import { mockAuthorizationServer, mockResourceServer } from '../testHelpers.js';
+import fetchMock from 'fetch-mock';
+import { ConsoleLogger, LogLevel } from '../logger.js';
+import { BigNumber } from 'bignumber.js';
+import { EventEmitter } from 'events';
+
+describe.skip('paymcp refunds', () => {
+  // Not implemented yet
+});

--- a/src/server/refund.ts
+++ b/src/server/refund.ts
@@ -1,0 +1,12 @@
+import { Response } from "express";
+import { BigNumber } from "bignumber.js";
+import { Charge, PayMcpConfig } from "./types.js";
+
+export function getRefunds(res: Response, refundErrors: PayMcpConfig["refundErrors"], charges: Charge[]): Charge[] {
+  // TODO: Implement refunds
+  return [];
+}
+
+export function processRefunds(user: string, refunds: Charge[], config: PayMcpConfig): void {
+  // TODO: Implement refunds
+}

--- a/src/server/token.ts
+++ b/src/server/token.ts
@@ -1,0 +1,11 @@
+import { Request, Response, NextFunction } from "express";
+import { BigNumber } from "bignumber.js";
+import { Charge, PayMcpConfig, TokenCheck, TokenProblem } from "./types.js";
+
+export function checkToken(req: Request, charges: Charge[], config: PayMcpConfig): TokenCheck {
+  return {
+    passes: false,
+    problem: TokenProblem.INVALID_TOKEN,
+    token: null
+  };
+}

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -1,0 +1,58 @@
+import { Request, Response, NextFunction } from "express";
+import { BigNumber } from "bignumber.js";
+import { Logger } from "../logger";
+import { OAuthResourceClient } from "../oAuthResource";
+import { TokenData } from "../types";
+import { Enum } from "@solana/web3.js/lib";
+
+export type McpOperation = string;
+export type McpOperationPattern = McpOperation | '*' | 'tools/call:*';
+export type Currency = 'USDC';
+export type Network = 'solana';
+export type RefundErrors = boolean | 'nonMcpOnly';
+
+export type PayMcpConfig = {
+  price: BigNumber | Record<McpOperationPattern, BigNumber> | ((req: Request, op: McpOperation, params: any) => Promise<BigNumber>);
+  destination: string;
+  // TODO: Can we auto-detect mountPath? ie can we look at all incoming requests and identify MCP ones?
+  mountPath?: string;
+  currency?: Currency;
+  network?: Network;
+  server?: string;
+  payeeName?: string | null;
+  allowHttp?: boolean;
+  refundErrors?: RefundErrors;
+  logger?: Logger;
+  oAuthResourceClient?: OAuthResourceClient;
+}
+
+export type PayMcpContext = {
+  logger: Logger;
+}
+
+export type Charge = {
+  amount: BigNumber;
+  currency: Currency;
+  network: Network;
+  destination: string;
+  operation: McpOperation;
+}
+
+export enum TokenProblem {
+  NO_TOKEN = 'no-token',
+  INVALID_TOKEN = 'invalid-token',
+  EXPIRED_TOKEN = 'expired-token',
+  INVALID_SCOPE = 'invalid-scope',
+  INVALID_AUDIENCE = 'invalid-audience'
+}
+
+type TokenCheckPass = {
+  passes: true;
+  token: TokenData;
+}
+type TokenCheckFail = {
+  passes: false;
+  problem: TokenProblem;
+  token: TokenData | null;
+}
+export type TokenCheck = TokenCheckPass | TokenCheckFail;

--- a/src/server/user.ts
+++ b/src/server/user.ts
@@ -1,0 +1,6 @@
+import { Request } from "express";
+import { TokenData } from "../types.js";
+
+export function setUser(req: Request, token: TokenData): string {
+  return '';
+}


### PR DESCRIPTION
Creates a new `/server` directory to host the new `paymcp()` function described in the [design doc](https://docs.google.com/document/d/1COQtzRxvY-zKKWqiTIZHjJh72VZPBkBn-KuDpHQ4ORo/edit?tab=t.0#heading=h.mvwczbgzczem)

This PR sets the high-level structure and starts the implementation with MCP operation parsing.