### PR TITLE
[NOV-41] Remove logic supporting old payment ID / signature

### DIFF
--- a/src/solanaPaymentMaker.test.ts
+++ b/src/solanaPaymentMaker.test.ts
@@ -5,24 +5,6 @@ import bs58 from "bs58";
 import nacl from "tweetnacl";
 import naclUtil from "tweetnacl-util";
 
-describe('solanaPaymentMaker.signBySource', () => {
-  it('should sign a payment by the source', async () => {
-    // This test is mainly here to force someone to read this if they change the signing,
-    // because you'll also need to account for that on the server side
-    const keypair = Keypair.generate();
-    const paymentMaker = new SolanaPaymentMaker('https://example.com', bs58.encode(keypair.secretKey));
-    const paymentId = 'test-payment-id';
-    const requestId = 'test-request-id';
-
-    const messageBytes = naclUtil.decodeUTF8(requestId + paymentId);
-    const signature = nacl.sign.detached(messageBytes, keypair.secretKey);
-    const expected = Buffer.from(signature).toString('base64');
-
-    const res = await paymentMaker.signBySource(requestId, paymentId);
-    expect(res).toBe(expected);
-  });
-});
-
 describe('solanaPaymentMaker.generateJWT', () => {
   it('should generate a valid JWT with default payload', async () => {
     const keypair = Keypair.generate();

--- a/src/solanaPaymentMaker.ts
+++ b/src/solanaPaymentMaker.ts
@@ -77,13 +77,4 @@ export class SolanaPaymentMaker implements PaymentMaker {
     );
     return transactionHash;
   }
-
-  signBySource = async (requestId: string, transactionId: string): Promise<string> => {
-    console.log("GENERATING SIGNATURE", requestId, transactionId, this.source.publicKey.toBase58());
-    // https://solana.com/developers/cookbook/wallets/sign-message
-    const messageBytes = naclUtil.decodeUTF8(requestId + transactionId);
-    const signature = nacl.sign.detached(messageBytes, this.source.secretKey);
-    const res = Buffer.from(signature).toString('base64');
-    return res;
-  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,6 @@ export type CustomJWTPayload = {
 
 export interface PaymentMaker {
   makePayment: (amount: BigNumber, currency: string, receiver: string, resourceName?: string) => Promise<string>;
-  signBySource: (requestId: string, message: string) => Promise<string>;
   generateJWT: (paymentIds?: string[]) => Promise<string>;
 }
 


### PR DESCRIPTION
# Description

In https://github.com/novellum-ai/paymcp/pull/50 we removed PayMCP support for the payment id / signature format. This PR removes code that would send over paymentId:signature 

# Motivation
https://linear.app/novellum/issue/NOV-41/modify-all-code-using-paymcp-client-to-utilize-the-new-jwt-access

# Testing
Automated tests pass