### PR TITLE
Use fetch for oAuthChannel fetch if only the former provided

### DIFF
--- a/src/client/payMcpClient.buildConfig.test.ts
+++ b/src/client/payMcpClient.buildConfig.test.ts
@@ -1,0 +1,24 @@
+import { SqliteOAuthDb } from '../common/oAuthDb';
+import { OAuthAuthenticationRequiredError } from './oAuth.js';
+import { describe, it, expect, vi } from 'vitest';
+import fetchMock from 'fetch-mock';
+import { mockResourceServer, mockAuthorizationServer } from './clientTestHelpers.js';
+import { PayMcpFetcher } from './payMcpFetcher.js';
+import { OAuthDb, FetchLike, DEFAULT_AUTHORIZATION_SERVER } from '../common/types.js';
+import { PaymentMaker } from './types.js';
+import { buildClientConfig, payMcpClient } from './payMcpClient.js';
+
+describe('buildConfig', () => {
+  it('should use fetchFn for oAuthChannelFetch if the former is provided and not the latter', () => {
+    const fetchFn = vi.fn();
+    const config = buildClientConfig({
+      fetchFn,
+      mcpServer: 'https://example.com/mcp',
+      account: {
+        accountId: 'bdj',
+        paymentMakers: {}
+      }
+    });
+    expect(config.oAuthChannelFetch).toBe(fetchFn);
+  });
+});

--- a/src/client/payMcpFetcher.oauth.test.ts
+++ b/src/client/payMcpFetcher.oauth.test.ts
@@ -24,7 +24,7 @@ function payMcpFetcher(fetchFn: FetchLike, paymentMakers?: {[key: string]: Payme
   });
 }
 
-describe('payMcpClient.fetch oauth', () => {
+describe('payMcpFetcher.fetch oauth', () => {
   it('should auth using the payment maker if one is available', async () => {
     const f = fetchMock.createInstance();
     mockResourceServer(f, 'https://example.com', '/mcp', DEFAULT_AUTHORIZATION_SERVER)

--- a/src/client/payMcpFetcher.payment.test.ts
+++ b/src/client/payMcpFetcher.payment.test.ts
@@ -34,7 +34,7 @@ function payMcpFetcher(
   });
 }
 
-describe('payMcpClient.fetch payment', () => {
+describe('payMcpFetcher.fetch payment', () => {
   it('should make a payment if the server response is a paymcp payment request error', async () => {
     const f = fetchMock.createInstance();
     const errTxt = CTH.paymentRequiredMessage(DEFAULT_AUTHORIZATION_SERVER, 'foo');


### PR DESCRIPTION
Otherwise, you have to explicitly set both `fetchFn` and `oAuthChannelFetch` to your custom fetch implementation, which is annoying.